### PR TITLE
Fix broken 404 page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,3 +5,14 @@
  */
 
 // You can delete this file if you're not using it
+
+const path = require('path')
+
+exports.createPages = async ({ actions }) => {
+  const { createPage } = actions
+  const page404 = path.resolve('src/pages/page_404.bs.js')
+  createPage({
+    path: '404',
+    component: page404,
+  })
+}

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,3 @@
+import page_404 from './page_404.bs'
+
+export default page_404

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,3 +1,0 @@
-import page_404 from './page_404.bs'
-
-export default page_404

--- a/src/pages/page_404.re
+++ b/src/pages/page_404.re
@@ -3,10 +3,9 @@ let make = () => {
   <Layout>
     <h1> {React.string("NOT FOUND")} </h1>
     <p>
-      {React.string(
-         "You just hit a route that doesn&#39;t exist... the
-    sadness.",
-       )}
+      {React.string("You just hit a route that doesn't exist... the sadness.")}
     </p>
   </Layout>;
 };
+
+let default = make;


### PR DESCRIPTION
Not sure if this is the best approach, so let me know if there's anything I can fix.

I'm going to investigate if there's a way to output a different name for the generated bucklescript file (E.e. `X.re` becomes `Xx.bs.js` instead of `X.bs.js`)

EDIT: Antonio mentioned a hacky solution for renaming `page_404.bs.js` to `404.js` at compile-time with the `js-post-builld` hook (https://bucklescript.github.io/docs/en/build-configuration#js-post-build). Not sure if we want to take this approach, but at least it's out there!