### PR TITLE
Refactoring key to work as union of color and style

### DIFF
--- a/src/re/Types.re
+++ b/src/re/Types.re
@@ -29,20 +29,7 @@ type style = [
   | `NoseStyle
 ];
 
-type key = [
-  | `SkinStyle
-  | `SkinColor
-  | `HairStyle
-  | `HairColor
-  | `FacialHairStyle
-  | `FacialHairColor
-  | `BodyStyle
-  | `BodyColor
-  | `EyesStyle
-  | `MouthStyle
-  | `NoseStyle
-  | `BackgroundColor
-];
+type key = [color | style];
 
 type styles = {
   skin: string,


### PR DESCRIPTION
This PR solves issue https://github.com/draftbit/avatar-generator/issues/23.

I did a refactor of the `key` type which is a union type of `style` and `color` type.

Fixes https://github.com/draftbit/avatar-generator/issues/23.
