### PR TITLE
Attach personas.draftbit.com as Worker custom domain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,12 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "personas",
   "compatibility_date": "2026-07-03",
+  "routes": [
+    {
+      "pattern": "personas.draftbit.com",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "directory": "./dist",
     "not_found_handling": "404-page"


### PR DESCRIPTION
Declares the custom domain in wrangler.jsonc so the CI deploy attaches it via the Cloudflare API. Note: if a conflicting DNS record for personas.draftbit.com exists (the old Netlify record), the deploy will report it and the record needs to be removed first — that is the cutover from Netlify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)