### PR TITLE
Self-destroying service worker for stale Gatsby offline caches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,26 @@
+// Self-destroying service worker.
+//
+// The pre-2026 Gatsby site (gatsby-plugin-offline) registered a service
+// worker at this URL that cached the entire app shell, so returning
+// visitors get the old site served from cache. When their browser
+// fetches this file on its background update check, this worker takes
+// over, purges every cache, unregisters itself, and reloads open tabs
+// so they pick up the current site immediately.
+//
+// Safe to delete once old-site traffic has died off.
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+      await self.registration.unregister();
+      const clients = await self.clients.matchAll({ type: "window" });
+      clients.forEach((client) => client.navigate(client.url));
+    })(),
+  );
+});


### PR DESCRIPTION
## Summary

Returning visitors still have the old Gatsby site's `gatsby-plugin-offline` service worker installed, which serves the pre-migration site entirely from cache on their first visit back (observed on Brian's machine). `/sw.js` currently 404s, which does eventually unregister the worker — but only after the stale visit.

This ships the standard self-destroying service worker at the old `/sw.js` URL: the browser's background update check installs it, it purges all caches, unregisters itself, and reloads open tabs, so returning visitors converge on the current site within seconds of landing.

Safe to remove once old-site traffic has died off.

## Verification

- `node --check` passes on the worker script.
- After deploy: `curl -I https://personas.draftbit.com/sw.js` returns 200 with a JS content type (previously 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)