### PR TITLE
3x3 styler grid on desktop

### DIFF
--- a/src/components/AvatarGenerator.css
+++ b/src/components/AvatarGenerator.css
@@ -1,5 +1,6 @@
 .AvatarGenerator-container {
   position: relative;
+  width: 100%;
   max-width: 780px;
   box-shadow: 0 4px 6px 0 rgba(24, 33, 45, 0.06);
   background-color: #ffffff;
@@ -79,11 +80,10 @@
     padding-left: 48px;
     padding-right: 48px;
     width: 100%;
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: space-between;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    justify-items: center;
+    align-items: start;
     margin-bottom: 48px;
   }
 }


### PR DESCRIPTION
The nine stylers now sit in three balanced rows of three on ≥768px viewports (was 4/4/1 with the ninth orphaned). Mobile unchanged. Verified via screenshots at 1280/800/375.

⚠️ Do not merge — awaiting Brian's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)